### PR TITLE
3.2.3 build

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,15 +1,13 @@
 {% set version = "3.2.3" %}
+{% set name = "scs" %}
 
 package:
-  name: scs
+  name: {{ name }}
   version: {{ version }}
 
 source:
-  - url: https://github.com/bodono/scs-python/archive/refs/tags/{{ version }}.tar.gz
-    sha256: 7592805810fb6da09955dc45322b2d376bca993928c972f472f1a5352821ddcd
-  # include submodule (not in github tarball due to dear-github/dear-github#214)
-  - url: https://github.com/cvxgrp/scs/archive/refs/tags/{{ version }}.tar.gz
-    folder: scs
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: e3bd779e7e977e3ae5a2f2035aa4c2a309e29082d59a722d5d6592edc4bdb4b3
 
 build:
   skip: true  # [py<37]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,6 +30,8 @@ requirements:
     - numpy
   run:
     - python
+    - libopenblas  # [not win]
+    - m2w64-openblas  # [win]
     - {{ pin_compatible('numpy') }}
     - scipy >=0.13.2
   run_constrained:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,8 +8,7 @@ source:
   - url: https://github.com/bodono/scs-python/archive/refs/tags/{{ version }}.tar.gz
     sha256: 7592805810fb6da09955dc45322b2d376bca993928c972f472f1a5352821ddcd
   # include submodule (not in github tarball due to dear-github/dear-github#214)
-  - git_url: https://github.com/cvxgrp/scs.git
-    git_rev: fa32d873d1812d6b80597a417d8e61a3a224ad50
+  - url: https://github.com/cvxgrp/scs/archive/refs/tags/{{ version }}.tar.gz
     folder: scs
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,8 +23,8 @@ requirements:
   build:
     - {{ compiler('c') }}
   host:
-    - libopenblas  # [not win]
-    - m2w64-openblas  # [win]
+    - libopenblas 0.3.21 # [not win]
+    - m2w64-openblas 0.2.19 # [win]
     - python
     - setuptools
     - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,6 +25,7 @@ requirements:
     - m2w64-openblas 0.2.19 # [win]
     - python
     - setuptools
+    - wheel
     - pip
     - numpy
   run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,11 +10,10 @@ source:
   sha256: e3bd779e7e977e3ae5a2f2035aa4c2a309e29082d59a722d5d6592edc4bdb4b3
 
 build:
+  # Windows is missing libopenblas
   skip: true  # [py<37 or win]
   number: 0
   script:
-    #- export BLAS_LAPACK_LIB_PATHS="$PREFIX/lib"    # [unix]
-    #- export BLAS_LAPACK_LIBS="lapack:cblas:blas"   # [unix]
     - {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,8 @@ requirements:
   build:
     - {{ compiler('c') }}
   host:
-    - libopenblas
+    - libopenblas  # [not win]
+    - m2w64-openblas  # [win]
     - python
     - setuptools
     - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -48,9 +48,7 @@ test:
   source_files:
     - test/
   commands:
-    - pytest test/ -v  # [not ppc64le]
-    # NOTE: test suite is skipped on ppc due to bugs in QEMU code that cause
-    # CI to fail, even though the tests should run through on native hardware
+    - pytest test/ -v
     - pip check
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -64,6 +64,7 @@ about:
     and power cone programs (PCPs), or problems with any combination of
     those cones.
   dev_url: https://github.com/bodono/scs-python
+  doc_url: https://www.cvxgrp.org/scs/
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,9 +21,6 @@ build:
 
 requirements:
   build:
-    - python                                 # [build_platform != target_platform]
-    - cross-python_{{ target_platform }}     # [build_platform != target_platform]
-    - numpy                                  # [build_platform != target_platform]
     - {{ compiler('c') }}
   host:
     - libblas

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,6 +13,7 @@ source:
     folder: scs
 
 build:
+  skip: true  # [py<37]
   number: 0
   script:
     - export BLAS_LAPACK_LIB_PATHS="$PREFIX/lib"    # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,12 +44,14 @@ test:
     - _scs_indirect
   requires:
     - pytest
+    - pip
   source_files:
     - test/
   commands:
     - pytest test/ -v  # [not ppc64le]
     # NOTE: test suite is skipped on ppc due to bugs in QEMU code that cause
     # CI to fail, even though the tests should run through on native hardware
+    - pip check
 
 about:
   home: https://github.com/bodono/scs-python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,8 +13,8 @@ build:
   skip: true  # [py<37]
   number: 0
   script:
-    - export BLAS_LAPACK_LIB_PATHS="$PREFIX/lib"    # [unix]
-    - export BLAS_LAPACK_LIBS="lapack:cblas:blas"   # [unix]
+    #- export BLAS_LAPACK_LIB_PATHS="$PREFIX/lib"    # [unix]
+    #- export BLAS_LAPACK_LIBS="lapack:cblas:blas"   # [unix]
     - {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
     sha256: 7592805810fb6da09955dc45322b2d376bca993928c972f472f1a5352821ddcd
   # include submodule (not in github tarball due to dear-github/dear-github#214)
   - git_url: https://github.com/cvxgrp/scs.git
-    git_rev: ac6840a3b3264950e6c300264cbf3937e0bcc6c5
+    git_rev: fa32d873d1812d6b80597a417d8e61a3a224ad50
     folder: scs
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,6 +29,7 @@ requirements:
     - numpy
   run:
     - python
+    - mkl  # [linux64 or (osx and x86)]
     - libopenblas
     - {{ pin_compatible('numpy') }}
     - scipy >=0.13.2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: e3bd779e7e977e3ae5a2f2035aa4c2a309e29082d59a722d5d6592edc4bdb4b3
 
 build:
-  skip: true  # [py<37]
+  skip: true  # [py<37 or win]
   number: 0
   script:
     #- export BLAS_LAPACK_LIB_PATHS="$PREFIX/lib"    # [unix]
@@ -21,8 +21,7 @@ requirements:
   build:
     - {{ compiler('c') }}
   host:
-    - libopenblas 0.3.21 # [not win]
-    - m2w64-openblas 0.2.19 # [win]
+    - libopenblas 0.3.21
     - python
     - setuptools
     - wheel
@@ -30,8 +29,7 @@ requirements:
     - numpy
   run:
     - python
-    - libopenblas  # [not win]
-    - m2w64-openblas  # [win]
+    - libopenblas
     - {{ pin_compatible('numpy') }}
     - scipy >=0.13.2
   run_constrained:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ build:
   script:
     - export BLAS_LAPACK_LIB_PATHS="$PREFIX/lib"    # [unix]
     - export BLAS_LAPACK_LIBS="lapack:cblas:blas"   # [unix]
-    - {{ PYTHON }} -m pip install . -vv
+    - {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,8 +10,7 @@ source:
   sha256: e3bd779e7e977e3ae5a2f2035aa4c2a309e29082d59a722d5d6592edc4bdb4b3
 
 build:
-  # Windows is missing libopenblas
-  skip: true  # [py<37 or win]
+  skip: true  # [py<37]
   number: 0
   script:
     - {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
@@ -20,7 +19,8 @@ requirements:
   build:
     - {{ compiler('c') }}
   host:
-    - libopenblas 0.3.21
+    - libopenblas 0.3.21  # [unix]
+    - mkl  # [win]
     - python
     - setuptools
     - wheel
@@ -28,8 +28,8 @@ requirements:
     - numpy
   run:
     - python
-    - mkl  # [linux64 or (osx and x86)]
-    - libopenblas
+    - mkl  # [x86]
+    - libopenblas  # [not win]
     - {{ pin_compatible('numpy') }}
     - scipy >=0.13.2
   run_constrained:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,8 +24,7 @@ requirements:
   build:
     - {{ compiler('c') }}
   host:
-    - libblas
-    - liblapack
+    - libopenblas
     - python
     - setuptools
     - pip


### PR DESCRIPTION
[Upstream repo](https://github.com/bodono/scs-python/tree/3.2.3)

`pycvx` <-- `scs`

- Skipping Windows due to missing `libopenblas`.
- Swapped source from Github to PyPI to ensure `scs` submodule is included.
- Added `mkl` for osx-64 and linux-64 to resolve overlinking error.