### PR TITLE
scs 3.2.8

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,36 +1,36 @@
-{% set version = "3.2.3" %}
 {% set name = "scs" %}
+{% set version = "3.2.8" %}
 
 package:
-  name: {{ name }}
+  name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: e3bd779e7e977e3ae5a2f2035aa4c2a309e29082d59a722d5d6592edc4bdb4b3
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 388ba6e6d77ac3ded38eb782eafece3df7b56ace2929135760a4bd7b251b6a08
 
 build:
+  number: 0
   # Windows is missing lapack and blas. 
   # Substituting mkl isn't supported by the python wrapper.
-  skip: true  # [py<37 or win]
-  number: 0
-  script:
-    - {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+  skip: true  # [py<39 or win]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   build:
+    - {{ stdlib('c') }}
     - {{ compiler('c') }}
   host:
-    - libopenblas 0.3.21
-    - python
-    - setuptools <65.6.0
-    - wheel
     - pip
-    - numpy
+    - python
+    - meson-python
+    - ninja-base
+    - openblas {{ openblas }}
+    - numpy {{ numpy }}
+    - scipy
   run:
     - python
-    - mkl  # [x86]
-    - libopenblas
+    - openblas
     - {{ pin_compatible('numpy') }}
     - scipy >=0.13.2
   run_constrained:
@@ -38,18 +38,16 @@ requirements:
     - cvxpy >1.1.15
 
 test:
+  source_files:
+    - test
   imports:
     - scs
-    - _scs_direct
-    - _scs_indirect
   requires:
-    - pytest
     - pip
-  source_files:
-    - test/
+    - pytest
   commands:
-    - pytest test/ -v
     - pip check
+    - pytest -v test
 
 about:
   home: https://github.com/bodono/scs-python


### PR DESCRIPTION
scs 3.2.8

**Destination channel:** default

### Links

- [PKG-9734](https://anaconda.atlassian.net/browse/PKG-9734)
- dev_url:        https://github.com/bodono/scs-python.git
- conda_forge:    https://github.com/conda-forge/scs-feedstock
- pypi:           https://pypi.org/project/scs/3.2.8
- pypi inspector: https://inspector.pypi.io/project/scs/3.2.8

### Explanation of changes:

- new version number


[PKG-9734]: https://anaconda.atlassian.net/browse/PKG-9734?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ