### PR TITLE
Build with open-blas on windows.

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,6 +1,0 @@
-channels:
-  - https://staging.continuum.io/pbp/fs/openblas-feedstock/pr13/66809d1
-  - https://staging.continuum.io/pbp/fs/numpy-feedstock/pr133/63a47e9
-  - https://staging.continuum.io/pbp/fs/dsdp-feedstock/pr6/3f4f01b
-  - https://staging.continuum.io/pbp/fs/cvxopt-feedstock/pr13/0934250
-  - https://staging.continuum.io/pbp/fs/scipy-feedstock/pr56/9cededa

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,5 @@
+channels:
+  - https://staging.continuum.io/pbp/fs/openblas-feedstock/pr13/66809d1
+  - https://staging.continuum.io/pbp/fs/numpy-feedstock/pr133/63a47e9
+  - https://staging.continuum.io/pbp/fs/dsdp-feedstock/pr6/3f4f01b
+  - https://staging.continuum.io/pbp/fs/cvxopt-feedstock/pr13/0934250

--- a/abs.yaml
+++ b/abs.yaml
@@ -3,3 +3,4 @@ channels:
   - https://staging.continuum.io/pbp/fs/numpy-feedstock/pr133/63a47e9
   - https://staging.continuum.io/pbp/fs/dsdp-feedstock/pr6/3f4f01b
   - https://staging.continuum.io/pbp/fs/cvxopt-feedstock/pr13/0934250
+  - https://staging.continuum.io/pbp/fs/scipy-feedstock/pr56/9cededa

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,29 @@
+c_compiler:            # [win]
+  - clang              # [win]
+cxx_compiler:          # [win]
+  - clang              # [win]
+c_compiler_version:    # [win]
+  - '20'               # [win]
+cxx_compiler_version:  # [win]
+  - '20'               # [win]
+
+numpy:
+  # python 3.10
+  - 2.4.4
+  # python 3.11
+  - 2.4.4
+  # python 3.12
+  - 2.4.4
+  # python 3.13
+  - 2.4.4
+  # python 3.14
+  - 2.4.4
+
+blas_impl:
+  - mkl                        # [(x86 or x86_64) and not osx]
+  - openblas
+
+fortran_compiler:
+  - flang             # [win]
+fortran_compiler_version:
+  - 20                # [win]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -7,18 +7,6 @@ c_compiler_version:    # [win]
 cxx_compiler_version:  # [win]
   - '20'               # [win]
 
-numpy:
-  # python 3.10
-  - 2.4.4
-  # python 3.11
-  - 2.4.4
-  # python 3.12
-  - 2.4.4
-  # python 3.13
-  - 2.4.4
-  # python 3.14
-  - 2.4.4
-
 blas_impl:
   - mkl                        # [(x86 or x86_64) and not osx]
   - openblas

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 388ba6e6d77ac3ded38eb782eafece3df7b56ace2929135760a4bd7b251b6a08
 
 build:
-  number: 1
+  number: 2
   skip: true  # [py<310]
   script:
     - {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv -Csetup-args=-Dlink_mkl=true  # [blas_impl == "mkl"]
@@ -19,9 +19,7 @@ build:
 requirements:
   build:
     - {{ stdlib('c') }}
-    - {{ compiler('c') }}  # [not win]
-    # _Complex is not being recognized by MSVC: https://github.com/cython/cython/issues/5512
-    - clang_win-64  # [win]
+    - {{ compiler('c') }}
   host:
     - pip
     - python


### PR DESCRIPTION
scs rebuild with openblas variant on windows.

**Destination channel:** defaults

### Links

- [PKG-13583](https://anaconda.atlassian.net/browse/PKG-13583) 


### Explanation of changes:

- Bump build number
- Add openblas to build matrix
- Switch windows to use clang via cbc so it can utilize the compiler macro.

https://github.com/AnacondaRecipes/scs-feedstock/pull/8 will follow this one

[PKG-13583]: https://anaconda.atlassian.net/browse/PKG-13583?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ